### PR TITLE
Allow running the app without an IDE

### DIFF
--- a/modules/app-server/app/build.gradle.kts
+++ b/modules/app-server/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
+    application
 }
 
 appProject()
@@ -13,4 +14,8 @@ dependencies {
     implementation(project(":modules:app-server:domain"))
     implementation("org.postgresql:postgresql:42.5.1")
     implementation(project(":modules:app-server:server"))
+}
+
+application {
+    mainClass.set("app.server.app.AppServerKt")
 }


### PR DESCRIPTION
This patch adds the `run` task to the `:modules:app-server:app` project, making it possible to run the app with `./gradlew :modules:app-server:app:run` without an IDE. This is more convenient because it uses no IDE-dependent configuration.

Even with this patch, a user still needs to have the correct JDK installed and set as JAVA_HOME, since the project does not declare [JVM toolchains](https://docs.gradle.org/current/userguide/toolchains.html). From the errors, I assume it's expected to be Java 17.

Also, the app crashes on startup with:
```
> Task :modules:app-server:dao:generateJooq FAILED
14:32:44 GRAVE Error in file: /home/[REDACTED]/datamaintain-monitoring/modules/app-server/dao/build/tmp/generateJooq/config.xml. Error : Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
org.postgresql.util.PSQLException: Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:319)
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:49)
	at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:247)
	at org.postgresql.Driver.makeConnection(Driver.java:434)
	at org.postgresql.Driver.connect(Driver.java:291)
	…
```
I assume a Postgres instance needs to be running somehow, but I don't see a docker-compose or similar file to start it. Is it normal that the `modules/app-server/dao/src/jooq/generated/domain` files are committed to the repository? The app seems to destroy them before even starting.